### PR TITLE
Handle null/empty values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.idea/

--- a/src/input-autocomplete-api-alt.vue
+++ b/src/input-autocomplete-api-alt.vue
@@ -6,7 +6,7 @@
     :placeholder="placeholder"
     :disabled="disabled"
     :class="font"
-    :model-value="value.text ?? value "
+    :model-value="value?.text || value || ''"
     :dir="direction"
     @update:model-value="onInput"
     @focus="activate"
@@ -146,6 +146,7 @@ export default {
     return {t, results, onInput, emitValue};
 
     function onInput(value) {
+      if(!value) return;
       if (value.length > 1) emitValue(value);
       fetchResults(value);
     }


### PR DESCRIPTION
stops interface from blowing up when there's no value in the field.